### PR TITLE
Set return of 'add_menu_page' to a class property

### DIFF
--- a/class-WP_Settings_Page.php
+++ b/class-WP_Settings_Page.php
@@ -32,7 +32,7 @@ class WP_Settings_Page {
 		$this->position = $args['position'];
 
 		if ( $this->parent_slug ) {
-			add_submenu_page(
+			$this->url_slug = add_submenu_page(
 				$this->parent_slug,
 				$this->page_title,
 				$this->menu_title,
@@ -41,7 +41,7 @@ class WP_Settings_Page {
 				$this->render_callback
 			);
 		} else {
-			add_menu_page(
+			$this->url_slug = add_menu_page(
 				$this->page_title,
 				$this->menu_title,
 				$this->capability,


### PR DESCRIPTION
So we can:

``` php
$settings_page = new WP_Settings_Page( array(
    'slug' => 'totally_rad_theme_settings',
    'menu_title' => 'Theme Settings',
    'page_title' => 'Theme Settings'
) );

add_action( 'admin_head-' . $settings_page->url_slug, 'enqueue_totally_rad_theme_js' );
```
