### PR TITLE
Return $this in add_field for chaining.

### DIFF
--- a/class-WP_Settings_Page.php
+++ b/class-WP_Settings_Page.php
@@ -150,6 +150,7 @@ class WP_Settings_Section {
 		$args['section'] = $this->slug;
 		$args['settings_page'] = $this->settings_page;
 		$fields[$args['slug']] = new WP_Settings_Field( $args );
+		return $this;
 	}
 }
 


### PR DESCRIPTION
Allows chaining:

``` php
$settings_page->get_section( 'general' )
    ->add_field( array(
        'slug' => 'footer_text',
        'title' => __( 'Footer Text', 'textdomain' ),
    ) )
    ->add_field( array(
        'slug' => 'comment_note',
        'title' => __( 'Comment Note', 'textdomain' ),
    ) );

```
