### PR TITLE
Return $this in add_* methods to enable chaining

### DIFF
--- a/class-WP_Settings_Page.php
+++ b/class-WP_Settings_Page.php
@@ -173,7 +173,7 @@ class WP_Settings_Field {
 		$defaults = array(
 			'slug'            => '',
 			'title'           => '',
-			'render_callback' => array( $this, 'render' ),
+			'render_callback' => NULL,
 			'settings_page'   => NULL,
 			'section'         => '',
 			'field_type'      => 'text'
@@ -198,7 +198,7 @@ class WP_Settings_Field {
 		add_settings_field(
 			$this->slug,
 			$this->title,
-			$this->render_callback,
+			array( $this, 'render' ),
 			$this->settings_page,
 			$this->section
 		);
@@ -212,8 +212,12 @@ class WP_Settings_Field {
 	 * Calls a submethod depending on the field_type.
 	 */
 	function render() {
-		$sub_render_method = 'render_' . $this->field_type;
-		call_user_func( array( $this, $sub_render_method ) );
+		if ( NULL === $this->render_callback ) {
+			$sub_render_method = 'render_' . $this->field_type;
+			call_user_func( array( $this, $sub_render_method ) );
+		} else {
+			call_user_func( $this->render_callback, $this );
+		}
 	}
 
 	/**

--- a/class-WP_Settings_Page.php
+++ b/class-WP_Settings_Page.php
@@ -84,6 +84,7 @@ class WP_Settings_Page {
 	 */
 	function add_section( $args ) {
 		$this->sections[$args['slug']] = new WP_Settings_Section( $args );
+		return $this;
 	}
 
 	function get_section( $slug ) {
@@ -145,6 +146,7 @@ class WP_Settings_Section {
 		$args['section'] = $this->slug;
 		$args['settings_page'] = $this->settings_page;
 		$fields[$args['slug']] = new WP_Settings_Field( $args );
+		return $this;
 	}
 }
 


### PR DESCRIPTION
``` php
$settings_page
    ->add_section( array(
        'slug'          => 'general',
        'title'         => 'General',
        'settings_page' => 'totally_rad_theme_settings',
    ) )->add_section( array(
        'slug'          => 'more',
        'title'         => 'More',
        'settings_page' => 'totally_rad_theme_settings',
    ) );

$settings_page->get_section( 'general' )
    ->add_field( array(
        'slug'  => 'footer_text',
        'title' => __( 'Footer Text', 'text-domain' ),
    ) )
    ->add_field( array(
        'slug'  => 'comment_note',
        'title' => __( 'Comment Note', 'text-domain' ),
    ) );
```
